### PR TITLE
remove reach me on my website

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Here are some ideas to get you started:
 - 🔭 I’m currently working on using Flask and React.
 - 🌱 I’m currently learning how to create web apps.
 - 👯 I’m looking to collaborate on a bunch of websites.
-- 📫 How to reach me: The Discussions Tab! Or my website: [https://techstudent11.herokuapp.com](https://techstudent11.herokuapp.com)
+- 📫 How to reach me: The Discussions Tab!
 - ⚡ Fun fact: "Expectations are the thief of joy." - Marques Brownlee (Tech Youtuber)
 - 📹 Oh yeah, I have a YouTube channel now: https://www.youtube.com/channel/UCzb9_b2UY29xuY-S8BsmpOg
 <img src="https://komarev.com/ghpvc/?username=TechStudent11" alt="Profile Views" />


### PR DESCRIPTION
The reachme on the website located at https://techstudent11.herokuapp.com/contact says to reach out to you on github, so this line being in the readme makes no sense cause never the less, anyone can only reach out to you via the discussions page.